### PR TITLE
Create Tags Template and Tags Page Creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "search.exclude": {
+        "**/node_modules": false
+    }
+}

--- a/cicd/terraform/.terraform.lock.hcl
+++ b/cicd/terraform/.terraform.lock.hcl
@@ -23,22 +23,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f1d83b3e5a29bae471f9841a4e0153eac5bccedbdece369e2f6186e9044db64e",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/cloudinit" {
-  version = "2.3.2"
-  hashes = [
-    "h1:Ar/DAbZQ9Nsj0BrqX6camrEE6U+Yq4E87DCNVqxqx8k=",
-    "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
-    "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
-    "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
-    "zh:436aa6c2b07d82aa6a9dd746a3e3a627f72787c27c80552ceda6dc52d01f4b6f",
-    "zh:458274c5aabe65ef4dbd61d43ce759287788e35a2da004e796373f88edcaa422",
-    "zh:54bc70fa6fb7da33292ae4d9ceef5398d637c7373e729ed4fce59bd7b8d67372",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:893ba267e18749c1a956b69be569f0d7bc043a49c3a0eb4d0d09a8e8b2ca3136",
-    "zh:95493b7517bce116f75cdd4c63b7c82a9d0d48ec2ef2f5eb836d262ef96d0aa7",
-    "zh:9ae21ab393be52e3e84e5cce0ef20e690d21f6c10ade7d9d9d22b39851bfeddc",
-    "zh:cc3b01ac2472e6d59358d54d5e4945032efbc8008739a6d4946ca1b621a16040",
-    "zh:f23bfe9758f06a1ec10ea3a81c9deedf3a7b42963568997d84a5153f35c5839a",
-  ]
-}

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -6,6 +6,7 @@ import * as _ from "lodash";
 import { CreatePageQueryData, MdxNode } from "./src/types/node-types";
 
 import { slugifyFunc } from "./src/utils";
+const TagsTemplate = path.resolve(`src/templates/tags-template/index.tsx`);
 
 const blogPostTemplate = path.resolve(`src/templates/post-template/index.tsx`);
 
@@ -42,9 +43,9 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
         return;
     }
 
-    const posts = result.data.postsGroup.edges
-    const tags = result.data.tagsGroup
-    console.log('TAGS: ', tags)
+    const posts = result.data.postsGroup.edges;
+    const tags = result.data.tagsGroup.group;
+
 
     reporter.info('*** GraphQL node query successful. Beginning createPages routine... ***')
 
@@ -54,6 +55,17 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
             path: `blog${node.frontmatter.slug}`,
             component: `${blogPostTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
             context: { slug: node.frontmatter.slug },
+        })
+    })
+
+    tags.forEach((tagGroup: any) => {
+        createPage({
+            path: `/tags/${_.kebabCase(tagGroup.fieldValue)}`,
+            component: TagsTemplate,
+            context: {
+                tag: tagGroup.fieldValue,
+                count: tagGroup.totalCount,
+            }
         })
     })
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -13,8 +13,8 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     const { createPage } = actions;
 
     const result = await graphql<CreatePageQueryData>(`
-        query {
-            allMdx {
+        {
+            postsGroup: allMdx {
                 edges {
                     node {
                         id
@@ -28,6 +28,12 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
                     }
                 }
             }
+            tagsGroup: allMdx {
+                group(field: {frontmatter: {tags: {name: SELECT }}}) {
+                    fieldValue
+                    totalCount
+                }
+            }
         }
     `);
 
@@ -36,12 +42,13 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
         return;
     }
 
-    const { allMdx } = result.data
-
+    const posts = result.data.postsGroup.edges
+    const tags = result.data.tagsGroup
+    console.log('TAGS: ', tags)
 
     reporter.info('*** GraphQL node query successful. Beginning createPages routine... ***')
 
-    allMdx.edges.forEach((edge) => {
+    posts.forEach((edge) => {
         const { node } = edge;
         createPage({
             path: `blog${node.frontmatter.slug}`,

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,8 +1,9 @@
 import path from "path";
 import readingTime from "reading-time";
 import type { GatsbyNode } from "gatsby"
+import * as _ from "lodash";
 
-import { CreatePageQueryData } from "./src/types/node-types";
+import { CreatePageQueryData, MdxNode } from "./src/types/node-types";
 
 import { slugifyFunc } from "./src/utils";
 
@@ -14,14 +15,16 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     const result = await graphql<CreatePageQueryData>(`
         query {
             allMdx {
-                nodes {
-                    id
-                    frontmatter {
-                        slug
-                        title
-                    } 
-                    internal {
-                        contentFilePath
+                edges {
+                    node {
+                        id
+                        frontmatter {
+                            slug
+                            title
+                        } 
+                        internal {
+                            contentFilePath
+                        }
                     }
                 }
             }
@@ -38,13 +41,16 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
 
     reporter.info('*** GraphQL node query successful. Beginning createPages routine... ***')
 
-    allMdx.nodes.forEach((mdxNode) => {
+    allMdx.edges.forEach((edge) => {
+        const { node } = edge;
         createPage({
-            path: `blog${mdxNode.frontmatter.slug}`,
-            component: `${blogPostTemplate}?__contentFilePath=${mdxNode.internal.contentFilePath}`,
-            context: { slug: mdxNode.frontmatter.slug },
+            path: `blog${node.frontmatter.slug}`,
+            component: `${blogPostTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
+            context: { slug: node.frontmatter.slug },
         })
     })
+
+
     reporter.info('*** createPages routine finished successfully ***')
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "v2-mes-net",
+  "name": "abort-to-orbit",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "v2-mes-net",
+      "name": "abort-to-orbit",
       "version": "1.0.0",
       "dependencies": {
         "@mdx-js/react": "^2.3.0",
@@ -4965,13 +4965,13 @@
       }
     },
     "node_modules/babel-plugin-remove-graphql-queries": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.10.0.tgz",
-      "integrity": "sha512-YVjBg0RD6aHE8LOWeuDSqadOB2lPV9FeGpc32rLClaDK+wHdIPaXYqUd9ty30UY30PfB/gDclyexXlfv7qgcxA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.12.1.tgz",
+      "integrity": "sha512-R5FyZLs+YfhCpUJkpSyVwIbaw9Ya4TC4xIOBJzPK9Z3u5XVCI459aykLPyfYAWwbsI9yvjm/Ux5ft4/U4rNvMQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.10.0"
+        "gatsby-core-utils": "^4.12.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9032,9 +9032,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.11.0.tgz",
-      "integrity": "sha512-W7pfrKgBchdk19g802IuPkCA2iJ69lRR1GzkfYjB8d1TuIQqf0l1z0lv7e+2kQqO+uQ5Yt3sGMMN2qMYMWfLXg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.12.1.tgz",
+      "integrity": "sha512-YW7eCK2M6yGQerT5LkdOHLZTNYMsDvcgeDMRy0q66FWKj7twPZX428I6NaLCMeF5dYoj1HOOO0u96iNlW5jcKQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
@@ -9336,9 +9336,9 @@
       }
     },
     "node_modules/gatsby-plugin-typescript": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.10.0.tgz",
-      "integrity": "sha512-e/jkoRHUxHlswOWTJBwkQCI9iBh8JcRq9YZaibfWwY9cZBEtBHjMDiic8zhQvyObnUKhke5IYDqLLCignrvC7A==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.12.1.tgz",
+      "integrity": "sha512-NIigc9TnhjLam/WAQxvVLKpRgjOXzDDgetOt2F2qtO+1KjMuUgLxHdd613Z0JoSPGpi5ug0KG8U99gh9zge7jA==",
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -9346,7 +9346,7 @@
         "@babel/plugin-proposal-optional-chaining": "^7.20.7",
         "@babel/preset-typescript": "^7.18.6",
         "@babel/runtime": "^7.20.13",
-        "babel-plugin-remove-graphql-queries": "^5.10.0"
+        "babel-plugin-remove-graphql-queries": "^5.12.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -22066,13 +22066,13 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.10.0.tgz",
-      "integrity": "sha512-YVjBg0RD6aHE8LOWeuDSqadOB2lPV9FeGpc32rLClaDK+wHdIPaXYqUd9ty30UY30PfB/gDclyexXlfv7qgcxA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.12.1.tgz",
+      "integrity": "sha512-R5FyZLs+YfhCpUJkpSyVwIbaw9Ya4TC4xIOBJzPK9Z3u5XVCI459aykLPyfYAWwbsI9yvjm/Ux5ft4/U4rNvMQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.10.0"
+        "gatsby-core-utils": "^4.12.1"
       }
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -25263,9 +25263,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.11.0.tgz",
-      "integrity": "sha512-W7pfrKgBchdk19g802IuPkCA2iJ69lRR1GzkfYjB8d1TuIQqf0l1z0lv7e+2kQqO+uQ5Yt3sGMMN2qMYMWfLXg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.12.1.tgz",
+      "integrity": "sha512-YW7eCK2M6yGQerT5LkdOHLZTNYMsDvcgeDMRy0q66FWKj7twPZX428I6NaLCMeF5dYoj1HOOO0u96iNlW5jcKQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
@@ -25482,9 +25482,9 @@
       }
     },
     "gatsby-plugin-typescript": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.10.0.tgz",
-      "integrity": "sha512-e/jkoRHUxHlswOWTJBwkQCI9iBh8JcRq9YZaibfWwY9cZBEtBHjMDiic8zhQvyObnUKhke5IYDqLLCignrvC7A==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.12.1.tgz",
+      "integrity": "sha512-NIigc9TnhjLam/WAQxvVLKpRgjOXzDDgetOt2F2qtO+1KjMuUgLxHdd613Z0JoSPGpi5ug0KG8U99gh9zge7jA==",
       "requires": {
         "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -25492,7 +25492,7 @@
         "@babel/plugin-proposal-optional-chaining": "^7.20.7",
         "@babel/preset-typescript": "^7.18.6",
         "@babel/runtime": "^7.20.13",
-        "babel-plugin-remove-graphql-queries": "^5.10.0"
+        "babel-plugin-remove-graphql-queries": "^5.12.1"
       }
     },
     "gatsby-plugin-utils": {

--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -18,17 +18,8 @@ export default function NavComponent(props: PageProps): ReactComponentElement<an
     const [isOpen, setIsOpen] = useState(false);
     const mobileNavRef = useRef<{ location: unknown }>({ location: null });
 
-    // This is the 1st implementation of closing the nav when we navigate to a new page.
-    // However it is very slow, noticeably slow.
-    // useEffect(() => {
-    //     return globalHistory.listen(({ action }) => {
-    //         if (action === 'PUSH') setIsOpen(false);
-    //     });
 
-    // }, [setIsOpen]);
     useEffect(() => {
-        console.log('useEffect running w/location : ', location)
-        console.log('useEffect running w/ref : ', mobileNavRef)
         if (!mobileNavRef.current.location) {
             mobileNavRef.current.location = location;
         }

--- a/src/templates/post-template/index.tsx
+++ b/src/templates/post-template/index.tsx
@@ -8,6 +8,12 @@ import { roundReadingTime } from "../../utils";
 import { blogPostTemplateContainer, blogPostTemplateTitlebox, blogPostTemplateProvider } from "./post-template.module.scss"
 
 export type PostTemplateDataProps = {
+    allMdx: {
+        totalCount: number
+        edges: Array<{
+            node: any
+        }>
+    }
     mdx: {
         body?: string
         frontmatter: {

--- a/src/templates/tags-template/index.tsx
+++ b/src/templates/tags-template/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { graphql, Link, PageProps } from 'gatsby';
+import { PostTemplateDataProps } from '../post-template';
+
+export default function TagsTemplate({ pageContext, data }: PageProps<PostTemplateDataProps>) {
+    const { title, date, tags, description, slug, bannerImage } = data.mdx.frontmatter;
+
+    const { edges, totalCount } = data.allMdx
+    const tagHeader = `${totalCount} post${totalCount === 1 ? '' : 's'
+        } tagged with "${tags?.[0]}"`;
+
+    return (
+        <div>
+            <h1>{tagHeader}</h1>
+            <ul>
+                {edges.map(({ node }) => {
+                    const { slug } = node.fields
+                    const { title } = node.frontmatter
+                    return (
+                        <li key={slug}>
+                            <Link to={slug}>{title}</Link>
+                        </li>
+                    )
+                })}
+            </ul>
+            {/*
+              This links to a page that does not yet exist.
+              You'll come back to it!
+            */}
+            <Link to="/tags">All tags</Link>
+        </div>
+    )
+}

--- a/src/templates/tags-template/index.tsx
+++ b/src/templates/tags-template/index.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { graphql, Link, PageProps } from 'gatsby';
 import { PostTemplateDataProps } from '../post-template';
 
-export default function TagsTemplate({ pageContext, data }: PageProps<PostTemplateDataProps>) {
-    const { title, date, tags, description, slug, bannerImage } = data.mdx.frontmatter;
+export default function TagsTemplate({ pageContext, data }: PageProps<any>): React.ReactComponentElement<any> {
+    const { tag, count } = pageContext;
+    const { edges } = data.allMdx;
 
-    const { edges, totalCount } = data.allMdx
-    const tagHeader = `${totalCount} post${totalCount === 1 ? '' : 's'
-        } tagged with "${tags?.[0]}"`;
+    const tagHeader = `${count} post${count === 1 ? '' : 's'
+        } tagged with "${tag}"`;
 
     return (
         <div>
             <h1>{tagHeader}</h1>
             <ul>
                 {edges.map(({ node }) => {
-                    const { slug } = node.fields
+                    const { slug } = node.frontmatter.slug
                     const { title } = node.frontmatter
                     return (
                         <li key={slug}>
@@ -23,11 +23,31 @@ export default function TagsTemplate({ pageContext, data }: PageProps<PostTempla
                     )
                 })}
             </ul>
-            {/*
-              This links to a page that does not yet exist.
-              You'll come back to it!
-            */}
-            <Link to="/tags">All tags</Link>
+
+            {/* <Link to="/tags">All tags</Link> */}
         </div>
     )
 }
+
+export const query = graphql`
+    query($tag: String) { 
+        allMdx(
+            filter: { frontmatter: { tags: {elemMatch: {name: { in: [$tag] } }}}}
+        ){
+            edges {
+                node {
+                    frontmatter {
+                        title
+                        slug
+                        tags {
+                            name
+                            slug
+                        }
+                    }
+                }
+            }
+            
+        }
+
+    }
+`

--- a/src/types/node-types.d.ts
+++ b/src/types/node-types.d.ts
@@ -4,8 +4,30 @@ export type IndexableObjectAny = {
     [key: string]: any;
 }
 
+// Add properties to the 'MdxNode' type as needed
+export type MdxNode = {
+    id: string
+    body: string
+    frontmatter: {
+        slug: string
+        title: string
+        description: string
+    }
+    internal: {
+        content?: any
+        contentDigest?: any
+        contentFilePath: string
+        type?: string
+    }
+}
+
 export type CreatePageQueryData = {
     allMdx: {
+        edges: Array<{
+            node: MdxNode
+        }>
+        // nodes is an abstraction of edges[nodes] but limits the graphing between similar topics. 
+        // use below 'nodes' for simplest querying where no association or relation needed
         nodes: Array<{
             id: string
             body: string

--- a/src/types/node-types.d.ts
+++ b/src/types/node-types.d.ts
@@ -22,7 +22,7 @@ export type MdxNode = {
 }
 
 export type CreatePageQueryData = {
-    allMdx: {
+    [key: string]: {
         edges: Array<{
             node: MdxNode
         }>
@@ -44,4 +44,5 @@ export type CreatePageQueryData = {
             }
         }>
     }
+
 }


### PR DESCRIPTION
- Added new aliased queries to gatsby-node createPage actions.
- Retyped several types being used for this purpose. There are still typescript issues we need to correct later.
- Added basic tags template to render a list with links based on the tag being shown.
- Still need to add a base 'tags' page (like aborttoorbit.com/tags) 